### PR TITLE
fixed: getBaseBranch when commit message with square brackets. #52

### DIFF
--- a/lib/gitremote.js
+++ b/lib/gitremote.js
@@ -72,7 +72,7 @@ exports.getRemoteBranches = function(cwd) {
 };
 
 var RE_CURRENT_BASE_BRANCHES = /^[ -+]*\*/;
-var RE_BASE_BRANCHE_NAME = /.*\[([^\]\^~]+).*/; // " +*   [MS170216105211~2^2] test: fixed lint"
+var RE_BASE_BRANCHE_NAME = /.*?\[([^\]\^~]+).*/; // " +*   [MS170216105211~2^2] test: fixed lint"
 exports.getBaseBranches = function(cwd) {
   var cwb = exports.getCurrentBranch(cwd);
   var baseBranches = child_process.execSync(


### PR DESCRIPTION
When commit message with square brackets (eg: "[foo] messages"),
getBaseBranch() will get the "foo", not the base branch name.