### PR TITLE
fix(github): Open PR by id in github

### DIFF
--- a/lib/scheme/github.js
+++ b/lib/scheme/github.js
@@ -23,7 +23,7 @@ module.exports = {
   'releases/new-with-tag': '/releases/new?tag={tag}',
   'releases/edit/tag-id': '/releases/edit/{tag}',
   'pulls': '/pulls',
-  'pulls/id': '/pulls/{pull-id}',
+  'pulls/id': '/pull/{pull-id}',
   'pulls/new': '/compare',
   'pulls/new-with-compare-branch': '/compare/{branch-B}?expand=1',
   'pulls/new-with-base-branch': '/compare/{branch-A}...{branch-B}',


### PR DESCRIPTION
The URL for specific pull request in Github ends with: "pull/{pull-id}"