### PR TITLE
fix: allow opening commits from another branch

### DIFF
--- a/bin/open-commander.js
+++ b/bin/open-commander.js
@@ -86,7 +86,11 @@ module.exports = function(argv, option, callback) {
       console.log();
     })
     .parse(argv);
-
+  
+  if (argv.includes("-branch")) {
+    commander.branch = argv[argv.indexOf("-branch") + 1];
+  }
+  
   var options = {
     category: 'home',
     cwd: commander.path ? path.dirname(commander.path) : option.cwd || process.cwd(),

--- a/bin/open-commander.js
+++ b/bin/open-commander.js
@@ -91,6 +91,7 @@ module.exports = function(argv, option, callback) {
     category: 'home',
     cwd: commander.path ? path.dirname(commander.path) : option.cwd || process.cwd(),
     hash: commander.branch || option.cwb || 'master',
+    branch: commander.branch || option.cwb || 'master',
     remote: commander.remote || 'origin',
     protocol: 'https',
     verbose: commander.verbose,

--- a/bin/open-commander.js
+++ b/bin/open-commander.js
@@ -246,7 +246,8 @@ module.exports = function(argv, option, callback) {
   case 'cis':
   case 'commits':
     options.category = 'commits';
-    if (commander.branch) {
+    // if (commander.branch) {
+    if (option.cwb) {
       options.cwb = option.cwb;
       options.category = 'commits-with-branch';
     }

--- a/bin/open-commander.js
+++ b/bin/open-commander.js
@@ -250,8 +250,7 @@ module.exports = function(argv, option, callback) {
   case 'cis':
   case 'commits':
     options.category = 'commits';
-    // if (commander.branch) {
-    if (option.cwb) {
+    if (commander.branch) {
       options.cwb = option.cwb;
       options.category = 'commits-with-branch';
     }


### PR DESCRIPTION
Currently, it is not possible to open the commits page without checkout-ing the corresponding branch. This is because the "branch" option is not passed from the command line arguments. Thus "options.branch" is undefined at: https://github.com/hotoo/gitopen/blob/5f7c46f23c0fa80d6b7a90277824a1215cc06195/lib/index.js